### PR TITLE
Set Default Version to SANA 2

### DIFF
--- a/frontend/src/context/JobSubmissionContext.tsx
+++ b/frontend/src/context/JobSubmissionContext.tsx
@@ -285,8 +285,8 @@ export function JobSubmissionProvider({
     children: React.ReactNode;
 }) {
     const navigate = useNavigate();
-    const [options, setOptions] = useState<Options>(defaultOptions["SANA1"]);
-    const [sanaVersion, setSanaVersion] = useState<SanaVersion>("SANA1");
+    const [options, setOptions] = useState<Options>(defaultOptions["SANA2"]);
+    const [sanaVersion, setSanaVersion] = useState<SanaVersion>("SANA2");
     const [file1, setFile1] = useState<File | null>(null);
     const [file2, setFile2] = useState<File | null>(null);
     const [fileError, setFileError] = useState<string[] | null>([]);


### PR DESCRIPTION
Changed `sanaVersion` and `options` in the JobSubmission context to use the latest version of SANA.

Tested that it defaulted to SANA2
<img width="994" height="536" alt="image" src="https://github.com/user-attachments/assets/80a3f1b7-7c5c-4f64-afb1-f74cd91be8bc" />
